### PR TITLE
Adjust actions to require twine 6.1.0

### DIFF
--- a/.github/workflows/secrets.yaml
+++ b/.github/workflows/secrets.yaml
@@ -36,6 +36,6 @@ jobs:
       - name: Build and deploy package
         run: |
           python setup.py sdist bdist_wheel
-          pip install twine==5.1.1
+          pip install twine==6.1.0
           echo "PYPI_API_TOKEN: ${{ secrets.SEPEHR }}"  # Print the API token
           twine upload -u '__token__' -p ${{ secrets.PYPI_API_TOKEN }} dist/*

--- a/.github/workflows/test-python-publish.yml
+++ b/.github/workflows/test-python-publish.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Publish package if tests passed
         if: success()  # Only runs if the previous steps were successful
         run: |
-          pip install twine==5.1.1
+          pip install twine==6.1.0
           echo "PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}"  # Print the API token for verification
           twine upload -u '__token__' -p ${{ secrets.PYPI_API_TOKEN }} dist/*


### PR DESCRIPTION
During the build process, the Metadata is created with version 2.4, but the hardcoded twine version 5.1.1 can only handle up to 2.3, requiring that it be changed to a more recent version like 6.1.0.

## Changes

- Adjusted Github Actions files to use a more recent version of twine (5.1.1 -> 6.1.0).