### PR TITLE
Fix internal module imports

### DIFF
--- a/nwmurl/urlgennwm.py
+++ b/nwmurl/urlgennwm.py
@@ -1,19 +1,13 @@
 from gevent import monkey
 monkey.patch_all()
-from validation_util import check_valid_urls
+if __name__ == '__main__':
+    import sys
+    sys.path.append('.')
+from nwmurl.validation_util import check_valid_urls
 from dateutil import rrule
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from itertools import product
-import time
 import os
-import unittest
-
-
-from concurrent.futures import ThreadPoolExecutor
-import gevent
-import requests
-from functools import partial
-from tqdm import tqdm
 
 
 rundict = {
@@ -689,35 +683,18 @@ def generate_urls(start_date,end_date, fcst_cycle, lead_time, varinput, geoinput
             for item in file_list:
                 file.write(f"{item}\n")
 
-start_date = "202310150000"
-end_date   = "202310150000"
-fcst_cycle = [0,8]
-lead_time = [1,18]
-varinput = 1
-geoinput = 1
-runinput = 1
-urlbaseinput = 2
-meminput = 1
-generate_urls(start_date, end_date, fcst_cycle, lead_time, varinput, geoinput, runinput, urlbaseinput, meminput)
-# Example usage
-file_list = create_file_list(runinput, varinput, geoinput, meminput, start_date, end_date, fcst_cycle, urlbaseinput, lead_time)
-valid_files = check_valid_urls(file_list)
 
-
-
-# class TestValidationScript(unittest.TestCase):
-#     def test_check_url(self):
-#         # Test a valid URL
-#         valid_url = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/"
-#         file_path = "filenamelist.txt"  # Provide a valid file path or filename
-#         result = check_url(file_path, valid_url)  # Provide both file path and URL
-#         self.assertEqual(result, valid_url)
-
-#         # Test an invalid URL
-#         invalid_url = ""
-#         result = check_url("", invalid_url)  # Provide an empty file path for an invalid URL
-#         self.assertIsNone(result)
-
-# if __name__ == '__main__':
-#     unittest.main()
-
+if __name__ == "__main__":
+    start_date = "202310150000"
+    end_date   = "202310150000"
+    fcst_cycle = [0,8]
+    lead_time = [1,18]
+    varinput = 1
+    geoinput = 1
+    runinput = 1
+    urlbaseinput = 2
+    meminput = 1
+    generate_urls(start_date, end_date, fcst_cycle, lead_time, varinput, geoinput, runinput, urlbaseinput, meminput)
+    # Example usage
+    file_list = create_file_list(runinput, varinput, geoinput, meminput, start_date, end_date, fcst_cycle, urlbaseinput, lead_time)
+    valid_files = check_valid_urls(file_list)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = nwmurl
+pythonpath = .

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ Then, you can use it in your Python code:
 """
 
 # Other information
-VERSION = "1.0.3"
+VERSION = "1.0.4"
 DESCRIPTION = "URL generator tool for National Water Model data"
 
 setup(

--- a/test/test_analysisAssim.py
+++ b/test/test_analysisAssim.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimExtend.py
+++ b/test/test_analysisAssimExtend.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimExtendNoDa.py
+++ b/test/test_analysisAssimExtendNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimHawaii.py
+++ b/test/test_analysisAssimHawaii.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimHawaiiNoDa.py
+++ b/test/test_analysisAssimHawaiiNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimNoDa.py
+++ b/test/test_analysisAssimNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimPuertorico.py
+++ b/test/test_analysisAssimPuertorico.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_analysisAssimPuertoricoNoDa.py
+++ b/test/test_analysisAssimPuertoricoNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_cases.py
+++ b/test/test_cases.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     selectvar,
     selectgeo,
     selectrun,

--- a/test/test_forcingAnalysisAssim.py
+++ b/test/test_forcingAnalysisAssim.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingAnalysisAssimExtend.py
+++ b/test/test_forcingAnalysisAssimExtend.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingAnalysisAssimHawaii.py
+++ b/test/test_forcingAnalysisAssimHawaii.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingAnalysisAssimPuertorico.py
+++ b/test/test_forcingAnalysisAssimPuertorico.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingMediumRange.py
+++ b/test/test_forcingMediumRange.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingShortRange.py
+++ b/test/test_forcingShortRange.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingShortRangeAssimHawaii.py
+++ b/test/test_forcingShortRangeAssimHawaii.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_forcingShortRangeAssimPuertorico.py
+++ b/test/test_forcingShortRangeAssimPuertorico.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_longRangeMem1.py
+++ b/test/test_longRangeMem1.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_longRangeMem2.py
+++ b/test/test_longRangeMem2.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_longRangeMem3.py
+++ b/test/test_longRangeMem3.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_longRangeMem4.py
+++ b/test/test_longRangeMem4.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem1.py
+++ b/test/test_mediumRangeMem1.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem2.py
+++ b/test/test_mediumRangeMem2.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem3.py
+++ b/test/test_mediumRangeMem3.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem4.py
+++ b/test/test_mediumRangeMem4.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem5.py
+++ b/test/test_mediumRangeMem5.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMem6.py
+++ b/test/test_mediumRangeMem6.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeMemNoDa.py
+++ b/test/test_mediumRangeMemNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_mediumRangeNoDa.py
+++ b/test/test_mediumRangeNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_shortRange.py
+++ b/test/test_shortRange.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_shortRangeAssimHawaii.py
+++ b/test/test_shortRangeAssimHawaii.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_shortRangeAssimPuertorico.py
+++ b/test/test_shortRangeAssimPuertorico.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test/test_shortRangeAssimPuertoricoNoDa.py
+++ b/test/test_shortRangeAssimPuertoricoNoDa.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from urlgennwm import (
+from nwmurl.urlgennwm import (
     generate_urls_operational,
 )  # Import the generate_urls_operational function from your script
 

--- a/test_module_valid.py
+++ b/test_module_valid.py
@@ -1,0 +1,4 @@
+import nwmurl
+# Bare minimum test to ensure that the package is importable 
+# from outside the module source directory
+print("Successfully imported nwmurl")


### PR DESCRIPTION
Current version of the module fails when imported from external scripts. The code works when run directly or internal to the module, including the pytests, but fails upon import from anywhere else.
This is due to the way python handles relative imports, i.e.

- Python will recognize filenames from within the parent folder of the script that is being run.
  - Alternatively, filenames from within the current working directory.
  - If file1.py, file2.py, file3.py, and file4.py are within a single folder, they can all import each other without worry.
- When the imported name is not within the current working directory, python assumes that it is a module.
  - This means that it when `urlgennwm` is imported from somewhere else, python recognizes `validation_util` as a module to find, rather than the `validation_util.py` that is right next to `urlgennwm.py` in the folder.

It's a big recurring headache.

To fix this, module files essentially have to reference one another relative to the parent module only, i.e. `nwmurl.validation_util` and `nwmurl.urlgennwm`. 
This breaks the ability to run the files directly, but can be ameliorated by using a `if __name__ == '__main__':` header guard, which I did in the course of fixing this.

## Changes
- Intra-module imports modified to use the relative-to-module system.
- Header guards added to `urlgennwm.py` to both allow direct running without breaking things, as well as to prevent the test at the bottom of the file from running whenever the file is imported.
- Pytest working directory changed, as well as modifying the imports in all the test files to work with the new scheme.
- Added a new `test_module_valid.py` file to the project directory that does nothing but check that the module can be imported properly.