### PR TITLE
migrate urls from nomads to gcs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ Then, you can use it in your Python code:
 """
 
 # Other information
-VERSION = "1.0.6"
+VERSION = "1.0.7"
 DESCRIPTION = "URL generator tool for National Water Model data"
 
 setup(

--- a/test/test_analysisAssim.py
+++ b/test/test_analysisAssim.py
@@ -14,7 +14,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 5  # Set to 5 for the analysis_assim folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -37,14 +37,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimExtend.py
+++ b/test/test_analysisAssimExtend.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 6  # Set to 6 for the analysis_assim_extend folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_extend folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend/nwm.t00z.analysis_assim_extend.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend/nwm.t08z.analysis_assim_extend.channel_rt.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimExtendNoDa.py
+++ b/test/test_analysisAssimExtendNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 7  # Set to 7 for the assim_extend_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the assim_extend_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend_no_da/nwm.t00z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_extend_no_da/nwm.t08z.analysis_assim_extend_no_da.channel_rt.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimHawaii.py
+++ b/test/test_analysisAssimHawaii.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 2
         runinput = 5  # Set to 5 for the analysis_assim_hawaii folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_hawaii folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim/nwm.t08z.analysis_assim.channel_rt.tm18.hawaii.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimHawaiiNoDa.py
+++ b/test/test_analysisAssimHawaiiNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 2
         runinput = 10  # Set to 10 for the analysis_assim_hawaii_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_hawaii_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.hawaii.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimNoDa.py
+++ b/test/test_analysisAssimNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 10  # Set to 5 for the analysis_assim_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimPuertorico.py
+++ b/test/test_analysisAssimPuertorico.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 3
         runinput = 5  # Set to 5 for the analysis_assim_puertorico folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_puertorico folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico/nwm.t00z.analysis_assim.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico/nwm.t08z.analysis_assim.channel_rt.tm18.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_analysisAssimPuertoricoNoDa.py
+++ b/test/test_analysisAssimPuertoricoNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 3
         runinput = 10  # Set to 10 for the analysis_assim_puertorico_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the analysis_assim_puertorico_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t00z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/analysis_assim_puertorico_no_da/nwm.t08z.analysis_assim_no_da.channel_rt.tm18.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingAnalysisAssim.py
+++ b/test/test_forcingAnalysisAssim.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 1
         runinput = 5  # Set to 5 for the forcing_analysis_assim folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_analysis_assim folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim/nwm.t00z.analysis_assim.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim/nwm.t08z.analysis_assim.forcing.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingAnalysisAssimExtend.py
+++ b/test/test_forcingAnalysisAssimExtend.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 1
         runinput = 6  # Set to 6 for the forcing_analysis_assim_extend folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_analysis_assim_extend folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm18.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm01.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_extend/nwm.t00z.analysis_assim_extend.forcing.tm18.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm01.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_extend/nwm.t08z.analysis_assim_extend.forcing.tm18.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingAnalysisAssimHawaii.py
+++ b/test/test_forcingAnalysisAssimHawaii.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 2
         runinput = 5  # Set to 5 for the forcing_analysis_assim_hawaii folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_analysis_assim_hawaii folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm18.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm01.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t00z.analysis_assim.forcing.tm18.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm01.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_hawaii/nwm.t08z.analysis_assim.forcing.tm18.hawaii.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingAnalysisAssimPuertorico.py
+++ b/test/test_forcingAnalysisAssimPuertorico.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 3
         runinput = 5  # Set to 5 for the forcing_analysis_assim_puertorico folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_analysis_assim_puertorico folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm18.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm01.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t00z.analysis_assim.forcing.tm18.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm01.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_analysis_assim_puertorico/nwm.t08z.analysis_assim.forcing.tm18.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingMediumRange.py
+++ b/test/test_forcingMediumRange.py
@@ -16,7 +16,7 @@ class TestGenerateURLs(unittest.TestCase):
         geoinput = 1
         runinput = 2  # Set to 2 for the forcing_medium_range folder
         urlbaseinput = 3
-        meminput = 1
+        meminput = None  # forcing_medium_range is incompatible with meminput
         write_to_file = True
 
         # Call the function to generate URLs
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_medium_range folder
         expected_urls = [
-            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
-            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range/nwm.t00z.medium_range.forcing.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range/nwm.t00z.medium_range.forcing.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range/nwm.t08z.medium_range.forcing.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range/nwm.t08z.medium_range.forcing.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range/nwm.t00z.medium_range.forcing.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range/nwm.t00z.medium_range.forcing.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range/nwm.t08z.medium_range.forcing.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range/nwm.t08z.medium_range.forcing.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingMediumRange.py
+++ b/test/test_forcingMediumRange.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 1
         runinput = 2  # Set to 2 for the forcing_medium_range folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_medium_range folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t00z.medium_range.forcing_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_medium_range_mem1/nwm.t08z.medium_range.forcing_1.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingShortRange.py
+++ b/test/test_forcingShortRange.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 10
         geoinput = 1
         runinput = 1  # Set to 1 for the forcing_short_range folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_short_range folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.variable_error.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.variable_error.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.variable_error.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.variable_error.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.variable_error.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.variable_error.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.variable_error.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.variable_error.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.variable_error.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.variable_error.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.variable_error.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.variable_error.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.variable_error.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.variable_error.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.variable_error.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.variable_error.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingShortRangeAssimHawaii.py
+++ b/test/test_forcingShortRangeAssimHawaii.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 2
         runinput = 1  # Set to 1 for the forcing_short_range_assim_hawaii folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_short_range_assim_hawaii folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_hawaii/nwm.t00z.short_range.forcing.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_hawaii/nwm.t08z.short_range.forcing.f018.hawaii.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_forcingShortRangeAssimPuertorico.py
+++ b/test/test_forcingShortRangeAssimPuertorico.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 5
         geoinput = 3
         runinput = 1  # Set to 1 for the forcing_short_range_assim_puerorico folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the forcing_short_range_assim_puerorico folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_puertorico/nwm.t00z.short_range.forcing.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/forcing_short_range_puertorico/nwm.t08z.short_range.forcing.f018.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_longRangeMem1.py
+++ b/test/test_longRangeMem1.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 4  # Set to 4 for the long_range_mem1 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the long_range_mem1 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem1/nwm.t00z.long_range.channel_rt_1.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem1/nwm.t08z.long_range.channel_rt_1.tm018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_longRangeMem2.py
+++ b/test/test_longRangeMem2.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 4  # Set to 4 for the long_range_mem1 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 2
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the long_range_mem1 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem2/nwm.t00z.long_range.channel_rt_2.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem2/nwm.t08z.long_range.channel_rt_2.tm018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_longRangeMem3.py
+++ b/test/test_longRangeMem3.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 4  # Set to 4 for the long_range_mem3 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 3
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the long_range_mem3 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem3/nwm.t00z.long_range.channel_rt_3.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem3/nwm.t08z.long_range.channel_rt_3.tm018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_longRangeMem4.py
+++ b/test/test_longRangeMem4.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 4  # Set to 4 for the long_range_mem4 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 4
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the long_range_mem4 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem4/nwm.t00z.long_range.channel_rt_4.tm018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/long_range_mem4/nwm.t08z.long_range.channel_rt_4.tm018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem1.py
+++ b/test/test_mediumRangeMem1.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem1 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem1 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem1/nwm.t00z.medium_range.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem1/nwm.t08z.medium_range.channel_rt_1.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem2.py
+++ b/test/test_mediumRangeMem2.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem2 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 2
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem2 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem2/nwm.t00z.medium_range.channel_rt_2.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem2/nwm.t08z.medium_range.channel_rt_2.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem3.py
+++ b/test/test_mediumRangeMem3.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem3 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 3
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem3 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem3/nwm.t00z.medium_range.channel_rt_3.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem3/nwm.t08z.medium_range.channel_rt_3.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem4.py
+++ b/test/test_mediumRangeMem4.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem4 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 4
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem4 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem5.py
+++ b/test/test_mediumRangeMem5.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem5 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 5
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem5 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem5/nwm.t00z.medium_range.channel_rt_5.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem5/nwm.t08z.medium_range.channel_rt_5.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMem6.py
+++ b/test/test_mediumRangeMem6.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_mem6 folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 6
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_mem6 folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem6/nwm.t00z.medium_range.channel_rt_6.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem6/nwm.t08z.medium_range.channel_rt_6.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeMemNoDa.py
+++ b/test/test_mediumRangeMemNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 2  # Set to 2 for the medium_range_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 4
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the medium_range_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t00z.medium_range.channel_rt_4.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_mem4/nwm.t08z.medium_range.channel_rt_4.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_mediumRangeNoDa.py
+++ b/test/test_mediumRangeNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 3  # Set to 5 for the analysis_assim folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -39,14 +39,14 @@ class TestGenerateURLs(unittest.TestCase):
         # Define the expected URLs or patterns for the analysis_assim folder
         # Define the expected URLs or patterns for the analysis_assim folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_no_da_mem1/nwm.t00z.medium_range_no_da.channel_rt_1.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/medium_range_no_da_mem1/nwm.t08z.medium_range_no_da.channel_rt_1.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_shortRange.py
+++ b/test/test_shortRange.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 1
         runinput = 1  # Set to 1 for the short_range folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the short_range folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f018.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f001.conus.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f018.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f001.conus.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f018.conus.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_shortRangeAssimHawaii.py
+++ b/test/test_shortRangeAssimHawaii.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 2
         runinput = 1  # Set to 1 for the short_range_assim_hawaii folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the short_range_assim_hawaii folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f018.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f001.hawaii.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t00z.short_range.channel_rt.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range/nwm.t08z.short_range.channel_rt.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t00z.short_range.channel_rt.f018.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f001.hawaii.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range/nwm.t08z.short_range.channel_rt.f018.hawaii.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_shortRangeAssimPuertorico.py
+++ b/test/test_shortRangeAssimPuertorico.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 3
         runinput = 1  # Set to 5 for the short_range_assim_puertorico folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the short_range_assim_puertorico folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico/nwm.t00z.short_range.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico/nwm.t00z.short_range.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico/nwm.t08z.short_range.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico/nwm.t08z.short_range.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico/nwm.t00z.short_range.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico/nwm.t00z.short_range.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico/nwm.t08z.short_range.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico/nwm.t08z.short_range.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico/nwm.t00z.short_range.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico/nwm.t00z.short_range.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico/nwm.t08z.short_range.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico/nwm.t08z.short_range.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico/nwm.t00z.short_range.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico/nwm.t00z.short_range.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico/nwm.t08z.short_range.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico/nwm.t08z.short_range.channel_rt.f018.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content

--- a/test/test_shortRangeAssimPuertoricoNoDa.py
+++ b/test/test_shortRangeAssimPuertoricoNoDa.py
@@ -15,7 +15,7 @@ class TestGenerateURLs(unittest.TestCase):
         varinput = 1
         geoinput = 3
         runinput = 11  # Set to 11 for the short_range_assim_puertorico_no_da folder
-        urlbaseinput = 2
+        urlbaseinput = 3
         meminput = 1
         write_to_file = True
 
@@ -38,14 +38,14 @@ class TestGenerateURLs(unittest.TestCase):
 
         # Define the expected URLs or patterns for the short_range_assim_puertorico_no_da folder
         expected_urls = [
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220112/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f018.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f001.puertorico.nc",
-            "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/post-processed/WMS/nwm.20220113/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220112/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico_no_da/nwm.t00z.short_range_no_da.channel_rt.f018.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f001.puertorico.nc",
+            "https://storage.googleapis.com/national-water-model/nwm.20220113/short_range_puertorico_no_da/nwm.t08z.short_range_no_da.channel_rt.f018.puertorico.nc",
         ]
 
         # Read the content of the file and check for the expected content


### PR DESCRIPTION
Issues #62 and #61 show that the NOMADS URL usage is broken. We are migrating the unit test assertions to use GCS URLs instead of NOMADS.


## Testing

1. unittests ran locally